### PR TITLE
refactor: Recorder to use a new version of the useMediaRecorder hook.

### DIFF
--- a/src/components/Recorder/index.js
+++ b/src/components/Recorder/index.js
@@ -1,56 +1,22 @@
-import { useState } from 'react'
+import { useMemo } from 'react'
 import PropTypes from 'prop-types'
-import useMediaRecorder from '../../hooks/useMediaRecorder'
-//import Visualizer from '../Visualizer'
 import Recording from '../Recording'
 import './style.css'
+import useMediaRecorder from "../../hooks/useMediaRecorder";
 
 const Recorder = ({stream}) => {
+    const { recorder, recordings, setRecordings, isRecording } = useMediaRecorder(stream);
+
     const defaultRecordClass = 'record-play'
-    const [recordingStateText, setRecordingStateText] = useState('Record')
-    const [recordings, setRecordings] = useState([])
-    const [recordButtonClassesText, setRecordButtonClassesText] = useState(defaultRecordClass)
-    let chunks = []
-
-    const onStop = () => {
-
-        const blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' })
-        chunks = []
-        const audioURL = window.URL.createObjectURL(blob)
-        setRecordings(recordings => {
-            return [...recordings, ...[{
-                stream: audioURL, 
-                name: new Date().toISOString().split('.')[0].split('T').join(' '),
-                id: `id${recordings.length}`
-            }]]
-        })
-        setRecordButtonClassesText(defaultRecordClass)
-        setRecordingStateText('Record')
-    }
-
-
-    const onStart = () => {
-
-    
-    }
-
-
-    const ondataavailable = (e) => {
-        chunks.push(e.data)
-    }
-
+    const recordButtonClassesText = useMemo(() => isRecording ? `${defaultRecordClass} recording-audio` : defaultRecordClass, [isRecording])
+    const recordingStateText = useMemo(() => isRecording ? 'Stop' : 'Record', [isRecording])
 
     const toggleRecording = () => {
-
-        if( 'Record' === recordingStateText ) {
-            setRecordButtonClassesText(defaultRecordClass + ' recording-audio')
-            setRecordingStateText('Stop')
-            mediaRecorder.start(1000)
+        if (!isRecording) {
+            recorder.start(1000)
         } else {
-            setRecordingStateText('Record')
-            mediaRecorder.stop()
+            recorder.stop();
         }
-
     }
 
     const editRecordingName = (id) => {
@@ -81,8 +47,6 @@ const Recorder = ({stream}) => {
         }
     }
 
-    const mediaRecorder = useMediaRecorder(stream, recordButtonClassesText, {onStart: onStart, onStop: onStop, ondataavailable: ondataavailable})
-
     const renderAudio = () => {
         let audios = recordings.map((recording, index) => {
             let customKey = `id${index}`
@@ -100,7 +64,6 @@ const Recorder = ({stream}) => {
         return audios
 
     }
-
 
     return (
         <>

--- a/src/hooks/useMediaRecorder.js
+++ b/src/hooks/useMediaRecorder.js
@@ -1,19 +1,66 @@
-import { useEffect, useState } from 'react'
+import {useMemo, useState} from "react";
 
-export default function useMediaRecorder (stream, trigger, events) {
-    const [mediaRecorder, setMediaRecorder] = useState(null)
+/**
+ * This media recorder hook keeps all the logic needed to perform an audio recording decoupling it from any component
+ * so it can be reused if needed.
+ *
+ * This way, when it comes to testing you only need to mock this `recorder` hook and its returned values.
+ *
+ * The hook in use would look like this:
+ * const { recording, recordings, setRecordings, isRecording } = useMediaRecorded(stream);
+ *
+ * The `setRecordings` method is exposed so that we can perform modifications to the list of recordings from the component
+ * avoiding to bloat the logic of this hook (tough it could also be a good idea to do so) but we kept it like this for simplicity
+ *
+ * @param {Object} stream
+ * @returns {{
+ * recorder: { start: Function, stop: Function },
+ * isRecording: boolean,
+ * recordings: any[],
+ * setRecordings: Function
+ * }}
+ *
+ */
+export default function useMediaRecorder(stream) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordings, setRecordings] = useState([]);
+  const [chunks, setChunks] = useState([]);
 
-    useEffect(() => {
-        if( mediaRecorder === null ) {
-            let mr = null
-            mr = new MediaRecorder(stream)
-            mr.onstop = events.onStop
-            mr.onstart = events.onStart
-            mr.ondataavailable = events.ondataavailable
-            setMediaRecorder(mr)
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [trigger])
+  const recorder = useMemo(() => new MediaRecorder(stream), [stream]);
 
-    return mediaRecorder
+  const handleStart = () => {
+    setIsRecording(true);
+  }
+
+  const handleStop = () => {
+    const blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' })
+    const audioURL = window.URL.createObjectURL(blob)
+
+    // push the new recording to the recordings list
+    setRecordings(currentRecordings => {
+      return [...currentRecordings, ...[{
+        stream: audioURL,
+        name: new Date().toISOString().split('.')[0].split('T').join(' '),
+        id: `id${currentRecordings.length}`
+      }]]
+    })
+
+    setChunks([])
+    setIsRecording(false);
+  }
+
+  const handleDataAvailable = (e) => {
+    setChunks(currentChunks => [...currentChunks, e.data]);
+  }
+
+  recorder.onstop = handleStop;
+  recorder.onstart = handleStart;
+  recorder.ondataavailable = handleDataAvailable;
+
+  return {
+    recorder,
+    recordings,
+    setRecordings,
+    isRecording,
+  }
 }


### PR DESCRIPTION
- useMediaRecorder has been completely decoupled from the Recorder component.
- Recorder component has now only the responsability to start, stop, render the list of recordings and modify the list of recordings.
- reorganized Recording test file with a new mocked implementation for the useMediaRecorder hook, and it's now more simple to test new cases.